### PR TITLE
Feature - linear momentum integrals in LAO basis

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -45,7 +45,7 @@ jobs:
 
     # Upload an artifact of the website on pull request.
     - name: Archive build
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: _site
         path: ./website/_build

--- a/gqcpy/src/Basis/SpinorBasis/GSpinorBasis_bindings.cpp
+++ b/gqcpy/src/Basis/SpinorBasis/GSpinorBasis_bindings.cpp
@@ -204,20 +204,13 @@ void bindGSpinorBases(py::module& module) {
             },
             "Return the spin-Zeeman operator expressed in this spinor basis.")
         
-        // .def(
-        //     "quantize",
-        //     [](const GSpinorBasis<complex, LondonGTOShell>& spinor_basis, const LinearMomentumOperator& op) {
-        //         return spinor_basis.quantize(op);
-        //     },
-        //     "Return the linear momentum operator expressed in this spinor basis.")
+        .def(
+            "quantize",
+            [](const GSpinorBasis<complex, LondonGTOShell>& spinor_basis, const LinearMomentumOperator& op) {
+                return spinor_basis.quantize(op);
+            },
+            "Return the linear momentum operator expressed in this spinor basis.")
 
-        // .def(
-        //     "quantize",
-        //     [](const GSpinorBasis<complex, LondonGTOShell>& spinor_basis, const CurrentDensityOperator& op) {
-        //         return spinor_basis.quantize(op);
-        //     },
-        //     "Return the current density operator expressed in this spinor basis.")
-        
         .def(
             "quantize",
             [](const GSpinorBasis<complex, LondonGTOShell>& spinor_basis, const FQMolecularMagneticHamiltonian& op) {

--- a/gqcpy/src/Basis/SpinorBasis/GSpinorBasis_bindings.cpp
+++ b/gqcpy/src/Basis/SpinorBasis/GSpinorBasis_bindings.cpp
@@ -203,7 +203,21 @@ void bindGSpinorBases(py::module& module) {
                 return spinor_basis.quantize(op);
             },
             "Return the spin-Zeeman operator expressed in this spinor basis.")
+        
+        // .def(
+        //     "quantize",
+        //     [](const GSpinorBasis<complex, LondonGTOShell>& spinor_basis, const LinearMomentumOperator& op) {
+        //         return spinor_basis.quantize(op);
+        //     },
+        //     "Return the linear momentum operator expressed in this spinor basis.")
 
+        // .def(
+        //     "quantize",
+        //     [](const GSpinorBasis<complex, LondonGTOShell>& spinor_basis, const CurrentDensityOperator& op) {
+        //         return spinor_basis.quantize(op);
+        //     },
+        //     "Return the current density operator expressed in this spinor basis.")
+        
         .def(
             "quantize",
             [](const GSpinorBasis<complex, LondonGTOShell>& spinor_basis, const FQMolecularMagneticHamiltonian& op) {

--- a/gqcpy/src/Basis/SpinorBasis/RSpinOrbitalBasis_bindings.cpp
+++ b/gqcpy/src/Basis/SpinorBasis/RSpinOrbitalBasis_bindings.cpp
@@ -185,13 +185,6 @@ void bindRSpinOrbitalBases(py::module& module) {
             },
             "Return the linear momentum operator expressed in this London spinor basis.");
 
-        // .def(
-        //     "quantize",
-        //     [](const RSpinOrbitalBasis<complex, LondonGTOShell>& spin_orbital_basis, const CurrentDensityOperator& op) {
-        //         return spin_orbital_basis.quantize(op);
-        //     },
-        //     "Return the current density operator expressed in this London spinor basis.");
-
     bindRSpinOrbitalBasisInterface(py_LondonRSpinOrbitalBasis);
     bindLondonSpinorBasisQuantizationInterface(py_LondonRSpinOrbitalBasis);
 }

--- a/gqcpy/src/Basis/SpinorBasis/RSpinOrbitalBasis_bindings.cpp
+++ b/gqcpy/src/Basis/SpinorBasis/RSpinOrbitalBasis_bindings.cpp
@@ -176,7 +176,21 @@ void bindRSpinOrbitalBases(py::module& module) {
             [](const RSpinOrbitalBasis<complex, LondonGTOShell>& spin_orbital_basis, const ElectronicQuadrupoleOperator& op) {
                 return spin_orbital_basis.quantize(op);
             },
-            "Return the electronic quadrupole operator expressed in this London spinor basis.");
+            "Return the electronic quadrupole operator expressed in this London spinor basis.")
+        
+        .def(
+            "quantize",
+            [](const RSpinOrbitalBasis<complex, LondonGTOShell>& spin_orbital_basis, const LinearMomentumOperator& op) {
+                return spin_orbital_basis.quantize(op);
+            },
+            "Return the linear momentum operator expressed in this London spinor basis.");
+
+        // .def(
+        //     "quantize",
+        //     [](const RSpinOrbitalBasis<complex, LondonGTOShell>& spin_orbital_basis, const CurrentDensityOperator& op) {
+        //         return spin_orbital_basis.quantize(op);
+        //     },
+        //     "Return the current density operator expressed in this London spinor basis.");
 
     bindRSpinOrbitalBasisInterface(py_LondonRSpinOrbitalBasis);
     bindLondonSpinorBasisQuantizationInterface(py_LondonRSpinOrbitalBasis);

--- a/website/examples/London-integrals.ipynb
+++ b/website/examples/London-integrals.ipynb
@@ -526,11 +526,61 @@
    "source": [
     "print(SZ1, SZ2, sep='\\n\\n')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edced0b0",
+   "metadata": {},
+   "source": [
+    "## Linear momentum integrals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "dc98323b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spinor_basis3 = gqcpy.LondonRSpinOrbitalBasis(molecule, \"STO-3G\", B1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "ce30bbf1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px, py, pz = spinor_basis3.quantize(gqcpy.LinearMomentumOperator()).allParameters()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "d262a684",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0.+0.j        , 0.-0.33184662j],\n",
+       "       [0.+0.33184662j, 0.+0.j        ]])"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pz"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },

--- a/website/examples/London-integrals.ipynb
+++ b/website/examples/London-integrals.ipynb
@@ -537,44 +537,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "id": "dc98323b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "spinor_basis3 = gqcpy.LondonRSpinOrbitalBasis(molecule, \"STO-3G\", B1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 37,
    "id": "ce30bbf1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "px, py, pz = spinor_basis3.quantize(gqcpy.LinearMomentumOperator()).allParameters()"
+    "px, py, pz = spinor_basis1.quantize(gqcpy.LinearMomentumOperator()).allParameters()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 39,
    "id": "d262a684",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "array([[0.+0.j        , 0.-0.33184662j],\n",
-       "       [0.+0.33184662j, 0.+0.j        ]])"
-      ]
-     },
-     "execution_count": 38,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[0.+0.j 0.+0.j 0.+0.j 0.+0.j]\n",
+      " [0.+0.j 0.+0.j 0.+0.j 0.+0.j]\n",
+      " [0.+0.j 0.+0.j 0.+0.j 0.+0.j]\n",
+      " [0.+0.j 0.+0.j 0.+0.j 0.+0.j]]\n",
+      "\n",
+      "[[0.+0.j 0.+0.j 0.+0.j 0.+0.j]\n",
+      " [0.+0.j 0.+0.j 0.+0.j 0.+0.j]\n",
+      " [0.+0.j 0.+0.j 0.+0.j 0.+0.j]\n",
+      " [0.+0.j 0.+0.j 0.+0.j 0.+0.j]]\n",
+      "\n",
+      "[[0.+0.j         0.-0.33184662j 0.+0.j         0.+0.j        ]\n",
+      " [0.+0.33184662j 0.+0.j         0.+0.j         0.+0.j        ]\n",
+      " [0.+0.j         0.+0.j         0.+0.j         0.-0.33184662j]\n",
+      " [0.+0.j         0.+0.j         0.+0.33184662j 0.+0.j        ]]\n"
+     ]
     }
    ],
    "source": [
-    "pz"
+    "print(px, py, pz, sep='\\n\\n')"
    ]
   }
  ],


### PR DESCRIPTION
## [ temporary workaround due to merging issues of [original PR](https://github.com/GQCG/GQCP/pull/1077) on main repo ]

**Short description**

Adding python bindings for the linear momentum and current density integrals in a London Atomic Orbital (LAO) basis.

**Related issues**

- #1076 

**To do**

- [x] Implement linear momentum operator bindings for London basis.
- [ ] ~Implement current density operator bindings for London basis~
- [x] Add examples to `London-integrals.ipynb`
