### PR TITLE
Bugfix/current density test error

### DIFF
--- a/gqcp/include/Basis/SpinorBasis/CurrentDensityMatrixElement.hpp
+++ b/gqcp/include/Basis/SpinorBasis/CurrentDensityMatrixElement.hpp
@@ -45,16 +45,16 @@ public:
     using Primitive = _Primitive;
 
     // The type of basis function that underlies this current density matrix element.
-    using BasisFunction = EvaluableLinearCombination<Scalar, Primitive>;
+    using BasisFunction = EvaluableLinearCombination<double, Primitive>;
 
     // The type of spatial orbital that underlies this current density matrix element.
     using SpatialOrbital = EvaluableLinearCombination<Scalar, BasisFunction>;
 
     // The type of the derivative of a primitive. The derivative of a Cartesian GTO is a linear combination of Cartesian GTOs.
-    using PrimitiveDerivative = EvaluableLinearCombination<Scalar, Primitive>;
+    using PrimitiveDerivative = EvaluableLinearCombination<double, Primitive>;
 
     // The type of the derivative of a basis function.
-    using BasisFunctionDerivative = EvaluableLinearCombination<Scalar, PrimitiveDerivative>;
+    using BasisFunctionDerivative = EvaluableLinearCombination<double, PrimitiveDerivative>;
 
     // The type of the derivative of a spatial orbital.
     using SpatialOrbitalDerivative = EvaluableLinearCombination<Scalar, BasisFunctionDerivative>;

--- a/gqcp/include/Basis/SpinorBasis/CurrentDensityMatrixElement.hpp
+++ b/gqcp/include/Basis/SpinorBasis/CurrentDensityMatrixElement.hpp
@@ -45,16 +45,16 @@ public:
     using Primitive = _Primitive;
 
     // The type of basis function that underlies this current density matrix element.
-    using BasisFunction = EvaluableLinearCombination<double, Primitive>;
+    using BasisFunction = EvaluableLinearCombination<Scalar, Primitive>;
 
     // The type of spatial orbital that underlies this current density matrix element.
     using SpatialOrbital = EvaluableLinearCombination<Scalar, BasisFunction>;
 
     // The type of the derivative of a primitive. The derivative of a Cartesian GTO is a linear combination of Cartesian GTOs.
-    using PrimitiveDerivative = EvaluableLinearCombination<double, Primitive>;
+    using PrimitiveDerivative = EvaluableLinearCombination<Scalar, Primitive>;
 
     // The type of the derivative of a basis function.
-    using BasisFunctionDerivative = EvaluableLinearCombination<double, PrimitiveDerivative>;
+    using BasisFunctionDerivative = EvaluableLinearCombination<Scalar, PrimitiveDerivative>;
 
     // The type of the derivative of a spatial orbital.
     using SpatialOrbitalDerivative = EvaluableLinearCombination<Scalar, BasisFunctionDerivative>;

--- a/gqcp/include/Basis/SpinorBasis/RSpinOrbitalBasis.hpp
+++ b/gqcp/include/Basis/SpinorBasis/RSpinOrbitalBasis.hpp
@@ -86,13 +86,19 @@ public:
     // The type that represents a density distribution for this spin-orbital basis.
     using DensityDistribution = FunctionProduct<SpatialOrbital>;
 
-    // The type of the derivative of a primitive. The derivative of a Cartesian GTO is a linear combination of Cartesian GTOs.
-    using PrimitiveDerivative = EvaluableLinearCombination<ExpansionScalar, Primitive>;
+    // figure out what a single primitive actually returns: 
+    //   for CartesianGTO that is double, for LondonCartesianGTO that is complex<double>
+    using PrimitiveScalar = decltype(
+        std::declval<Primitive>()(std::declval<Vector<double, 3>>())
+    );
 
-    // The type of the derivative of a basis function.
-    using BasisFunctionDerivative = EvaluableLinearCombination<ExpansionScalar, PrimitiveDerivative>;
+    // now the primitive‐derivative lives at the primitive’s own scalar
+    using PrimitiveDerivative = EvaluableLinearCombination<PrimitiveScalar, Primitive>;
 
-    // The type of the derivative of a spatial orbital.
+    // the basis‐function derivative uses the same contraction coefficients as the basis‐function itself
+    using BasisFunctionDerivative = EvaluableLinearCombination<PrimitiveScalar, PrimitiveDerivative>;
+
+    // and finally the spatial‐orbital derivative lives at the MO‐scalar level
     using SpatialOrbitalDerivative = EvaluableLinearCombination<ExpansionScalar, BasisFunctionDerivative>;
 
     // The type that represents a current density distribution for this spin-orbital basis.

--- a/gqcp/sandbox/CMakeLists.txt
+++ b/gqcp/sandbox/CMakeLists.txt
@@ -5,6 +5,7 @@ list(APPEND sandbox_target_sources
     # ${CMAKE_CURRENT_SOURCE_DIR}/test_sandbox.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/eval_ao_at_point_development.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/london_orbital_gradients.cpp    
+    ${CMAKE_CURRENT_SOURCE_DIR}/current_density_bugfixing.cpp 
 )
 
 set(sandbox_target_sources ${sandbox_target_sources} PARENT_SCOPE)

--- a/gqcp/sandbox/current_density_bugfixing.cpp
+++ b/gqcp/sandbox/current_density_bugfixing.cpp
@@ -1,0 +1,98 @@
+#include "Basis/SpinorBasis/RSpinOrbitalBasis.hpp"
+#include "QCMethod/HF/RHF/DiagonalRHFFockMatrixObjective.hpp"
+#include "QCMethod/HF/RHF/RHF.hpp"
+#include "QCMethod/HF/RHF/RHFSCFSolver.hpp"
+#include "QCModel/HF/RHF.hpp"
+
+// from RHF_test
+
+int main() {
+
+    using namespace GQCP::literals;
+
+    // Set up the molecular Hamiltonian in AO basis.
+    const GQCP::Molecule molecule {{GQCP::Nucleus(1, 0.0, 0.0, 0.0), GQCP::Nucleus(1, 0.0, 0.0, 1.0)}};
+    const auto N_P = molecule.numberOfElectronPairs();
+
+    const std::string basis_set {"STO-3G"};
+    GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> spin_orbital_basis {molecule, basis_set};
+
+    auto hamiltonian = spin_orbital_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));
+
+
+    // Read in the GAMESS-UK RHF wave function model parameters. Even though GQCP finds the same orbitals and orbital energies, the phase factors (and orbital coefficients for degenerated orbitals) are unlikely to be reproducible.
+    GQCP::MatrixX<double> C_matrix {2, 2};
+    // clang-format off
+    C_matrix << 0.5275464665,  1.5678230259,
+                0.5275464665, -1.5678230259;
+    // clang-format on
+    GQCP::RTransformation<double> C {C_matrix};
+
+    GQCP::VectorX<double> orbital_energies {2};
+    orbital_energies << -0.6757801904, 0.9418115528;
+
+    const GQCP::QCModel::RHF<double> rhf_parameters {N_P, orbital_energies, C};
+
+
+    // Since we're going to work with complex operators, we have to let a complex spin-orbital basis do the quantization.
+    GQCP::RSpinOrbitalBasis<GQCP::complex, GQCP::GTOShell> complex_spin_orbital_basis {molecule, basis_set};
+    GQCP::RTransformation<GQCP::complex> C_complex {C_matrix.cast<GQCP::complex>()};
+    complex_spin_orbital_basis.transform(C_complex);
+
+    spin_orbital_basis.transform(C);
+    hamiltonian.transform(C);
+
+
+    // Calculate the orbital Hessian.
+    const auto orbital_space = rhf_parameters.orbitalSpace();
+    auto A = rhf_parameters.calculateOrbitalHessianForImaginaryResponse(hamiltonian, orbital_space);
+
+
+    // Solve the CPHF equations for the angular momentum operator.
+    const auto L = complex_spin_orbital_basis.quantize(GQCP::AngularMomentumOperator());
+    const auto F_B = rhf_parameters.calculateMagneticFieldResponseForce(L);
+
+
+    auto environment_B = GQCP::LinearEquationEnvironment<GQCP::complex>(A.asMatrix(), -F_B);
+    auto solver_B = GQCP::LinearEquationSolver<GQCP::complex>::HouseholderQR();
+    solver_B.perform(environment_B);
+    const auto x = environment_B.x;
+
+
+    // Solve the CPHF equations for the linear momentum operator.
+    const auto p = complex_spin_orbital_basis.quantize(GQCP::LinearMomentumOperator());
+    const auto F_G = rhf_parameters.calculateGaugeOriginTranslationResponseForce(p);
+
+    // In order to check with the reference values, we have to convert our dyadic Cartesian (i.e. xy, xz, etc.) representation to a Cartesian (i.e. x,y,z) one.
+    GQCP::MatrixX<GQCP::complex> F_G_reduced {1, 3};
+    F_G_reduced.col(0) = 2 * F_G.col(3);  // x <--> yz
+    F_G_reduced.col(1) = 2 * F_G.col(4);  // y <--> zx
+    F_G_reduced.col(2) = 2 * F_G.col(0);  // z <--> xy
+
+
+    auto environment_G = GQCP::LinearEquationEnvironment<GQCP::complex>(A.asMatrix(), -F_G);
+    auto solver_G = GQCP::LinearEquationSolver<GQCP::complex>::HouseholderQR();
+    solver_G.perform(environment_G);
+
+    const auto y = environment_G.x;
+
+    // In order to check with the reference values, we have to convert our dyadic Cartesian (i.e. xy, xz, etc.) representation to a Cartesian (i.e. x, y, z) one.
+    GQCP::MatrixX<GQCP::complex> y_reduced {1, 3};
+    y_reduced.col(0) = 2 * y.col(3);  // x <--> yz
+    y_reduced.col(1) = 2 * y.col(4);  // y <--> zx
+    y_reduced.col(2) = 2 * y.col(0);  // z <--> xy
+
+
+    // Calculate the ipsocentric magnetic inducibility on a grid and check the results.
+    const auto j_op = complex_spin_orbital_basis.quantize(GQCP::CurrentDensityOperator());
+
+    const GQCP::Vector<double, 3> origin {-2.0, -2.0, -2.0};
+    const std::array<size_t, 3> steps {6, 6, 6};
+    const std::array<double, 3> step_sizes {0.8, 0.8, 0.8};
+    const GQCP::CubicGrid grid {origin, steps, step_sizes};
+
+    const auto J_field = GQCP::QCModel::RHF<GQCP::complex>::calculateIpsocentricMagneticInducibility(grid, orbital_space, x, y, j_op);
+    const auto& J_values = J_field.values();
+
+    return 0;
+}


### PR DESCRIPTION
Bugfix - current density tests failed due to assumed `double` scalar type of all basisfunction and primitives, which is not the case for LAOs (`complex<double>`)

Solved by discriminating between the SpinOrbital basis `ExpansionScalar` and the Scalar type used in the underlying GTO basis, `PrimitiveScalar`.